### PR TITLE
Fix format of the manpage NAME section

### DIFF
--- a/doc/sac2mseed.1
+++ b/doc/sac2mseed.1
@@ -1,6 +1,6 @@
 .TH SAC2MSEED 1 2017/04/03
 .SH NAME
-SAC to miniSEED converter
+sac2mseed \- SAC to miniSEED converter
 
 .SH SYNOPSIS
 .nf


### PR DESCRIPTION
When using the traditional man macro set, a correct NAME section
looks something like this:
```
  .SH NAME
  foo \- program to do something
```
Refer to the lexgrog(1) manual page, the groff_man(7) manual page,
and the groff_mdoc(7) manual page for details.

(This commit fixes a lintian warning encountered while building a
Debian package for sac2mseed.)